### PR TITLE
fix(vuln): CVE remediation 2026-04-25

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,3 +1,3 @@
 module github.com/hairyhenderson/gomplate/docs
 
-go 1.25.5
+go 1.26.2


### PR DESCRIPTION
Automated CVE fix: updated Go version in docs/go.mod (1.25.5 → 1.26.2). Trivy scan clean — 0 HIGH/CRITICAL with fix available.