### PR TITLE
fix(vuln): CVE remediation 2026-05-09

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,3 +1,3 @@
 module github.com/hairyhenderson/gomplate/docs
 
-go 1.26.2
+go 1.26.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hairyhenderson/gomplate/v4
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cuelang.org/go v0.13.2


### PR DESCRIPTION
Automated CVE fix: updated Go 1.26.2 → 1.26.3, fixing stdlib vulnerabilities (html/template XSS, net/http HTTP/2, net CNAME crash).