### PR TITLE
fix(deps): bump go to 1.26.4 and go-git to v5.19.1 [security]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hairyhenderson/gomplate/v4
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cuelang.org/go v0.13.2
@@ -99,7 +99,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=


### PR DESCRIPTION
## Why
The gomplate binary built from this fork is baked into the GitLab CNG `gitlab-base` image (via `gitlab-binary`). Its compiled `stdlib` and `go-git` versions therefore surface in image vulnerability scans of `gitlab-base`, `certificates`, `gitaly`, `gitlab-shell`, `cfssl-self-sign`.

At the current latest release `v4.3.4-alauda-31`, this module is `go 1.26.3` + `go-git/go-git v5.19.0`, which keeps the GitLab bundle scan reporting (PkgPath=null, i.e. compiled into the gomplate binary):

| CVE | Pkg | Installed | Fixed |
|---|---|---|---|
| CVE-2026-27145 / CVE-2026-42504 / CVE-2026-42507 | stdlib | 1.26.3 | 1.26.4 |
| CVE-2026-45570 / CVE-2026-45571 / GHSA-w5pp-99ch-qj29 | go-git/go-git/v5 | 5.19.0 | 5.19.1 |

These are the only findings left unaddressed after the gitlab-chart vuln fix; they cannot be fixed chart-side because they live in this prebuilt binary.

## What
- `go` directive `1.26.3` → `1.26.4` (forces the build toolchain to >= 1.26.4 under `GOTOOLCHAIN=auto`, clearing the stdlib CVEs).
- `go-git/go-git/v5` `v5.19.0` → `v5.19.1` (clears the go-git CVEs). `go-billy` is already at the fixed `v5.9.0`.

`go mod tidy` and `go mod verify` pass locally; diff is go.mod + go.sum only.

## Follow-up (not in this PR)
After this merges and a new release (e.g. `v4.3.4-alauda-32`) is cut, `gitlab-chart` must bump `GOMPLATE_VERSION` in `modules/dependencies/Containerfile.binary` to that tag and rebuild so the new binary lands in `gitlab-base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)